### PR TITLE
Added and Created Licensing Page Reflecting MIT License

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18104,6 +18104,7 @@
       "version": "6.1.12",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.1.12.tgz",
       "integrity": "sha512-n/O4PzRPhbYI0k1vKKayfti3C/IGcPf+DqcrOB7O/ab9x4u/zjqraneT5N45+sIe87cxrCApXM8Bna7NYxwoTA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/is-prop-valid": "1.2.2",
         "@emotion/unitless": "0.8.1",

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Contact from "./Component/Contact";
 import Blog from "./Component/Documetation/Blog";
 import Contributors from "./Component/Contributors"
 import { useState } from "react";
+import Licensing from "./Component/Licensing";
 
 
 import FeedbackButton from "./Component/Feedbtn";
@@ -40,6 +41,8 @@ function App() {
         <Route path="/feedback" element={<FeedbackModal />} />
         <Route path="/Contact" element={<Contact></Contact>}/>
         <Route path="*" element={<Error/>}/>
+        <Route path="/licensing" element={<Licensing/>}/>
+        
       </Routes>
       <Footer/> 
     </div>)

--- a/src/Component/Footer.jsx
+++ b/src/Component/Footer.jsx
@@ -43,7 +43,7 @@ function Footer() {
           <ul className="footer-links">
             <li><span> <a href="#">Privacy Policy</a></span></li>
             <li><span><a href="#">Terms and Conditions</a></span></li>
-            <li><span><a href="#">MIT License</a></span></li>
+            <li><span><a href="/licensing">MIT License</a></span></li>
             <li><span><a href="https://github.com/HimanshuNarware/CareerZunction_Intern?tab=coc-ov-file#readme">Code of Conduct</a></span></li>
           </ul>
           <h4 className="footer-heading">Get in touch</h4>

--- a/src/Component/Licensing.jsx
+++ b/src/Component/Licensing.jsx
@@ -1,0 +1,75 @@
+import { React, useEffect } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+  max-width: 800px;
+  margin: 0 auto;
+  margin-top: 60px;
+  bottom: 20px
+  padding: 20px;
+  font-family: Arial, sans-serif;
+  border-radius: 5px;
+  margin-bottom: 80px;
+`;
+
+const Title = styled.h1`
+  font-size: 2em;
+  margin-bottom: 20px;
+  text-align: left;
+  color: white;
+`;
+
+const Paragraph = styled.p`
+  font-size: 1em;
+  line-height: 1.6;
+  margin-bottom: 8px;
+  color: white;
+`;
+
+const Subtitle = styled.h2`
+  font-size: 1.5em;
+  margin-bottom: 8px;
+  justify-content: left;
+  padding: 0;
+  color: white;
+`;
+
+const Licensing = () => {
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, []);
+
+    return (
+        <Container>
+            <Title>Licensing</Title>
+            <Paragraph>Welcome to CareerZunction! This website is licensed under the MIT License. This page outlines the terms of the license and provides details on how you can use, modify, and distribute our software.</Paragraph>
+            <Subtitle>MIT License</Subtitle>
+            <Paragraph>Copyright (c) 2024 StartConnect-Hub</Paragraph>
+            <Paragraph>
+                Permission is hereby granted, free of charge, to any person obtaining a copy
+                of this software and associated documentation files (the "Software"), to deal
+                in the Software without restriction, including without limitation the rights
+                to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+                copies of the Software, and to permit persons to whom the Software is
+                furnished to do so, subject to the following conditions:
+            </Paragraph>
+            <Paragraph>
+                The above copyright notice and this permission notice shall be included in all
+                copies or substantial portions of the Software.
+            </Paragraph>
+            <Paragraph>
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+                IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+                FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+                AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+                LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+                OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+                SOFTWARE.
+            </Paragraph>
+            <Subtitle>Contact Information</Subtitle>
+            <p style={{ color: 'white' }}>If you have any questions or concerns about this licensing agreement, please contact us at Email: <a href="mailto:careerzunction@gmail.com" style={{ color: 'white' }}>careerzunction@gmail.com</a></p>
+        </Container>
+    );
+};
+
+export default Licensing;

--- a/src/Component/Licensing.jsx
+++ b/src/Component/Licensing.jsx
@@ -5,7 +5,6 @@ const Container = styled.div`
   max-width: 800px;
   margin: 0 auto;
   margin-top: 60px;
-  bottom: 20px
   padding: 20px;
   font-family: Arial, sans-serif;
   border-radius: 5px;
@@ -14,7 +13,7 @@ const Container = styled.div`
 
 const Title = styled.h1`
   font-size: 2em;
-  margin-bottom: 20px;
+  margin-bottom: 30px; /* Increased margin for more spacing */
   text-align: left;
   color: white;
 `;
@@ -22,16 +21,22 @@ const Title = styled.h1`
 const Paragraph = styled.p`
   font-size: 1em;
   line-height: 1.6;
-  margin-bottom: 8px;
+  margin-bottom: 20px; /* Increased margin for more spacing */
   color: white;
 `;
 
 const Subtitle = styled.h2`
   font-size: 1.5em;
-  margin-bottom: 8px;
+  margin-bottom: 20px; /* Increased margin for more spacing */
   justify-content: left;
   padding: 0;
   color: white;
+`;
+
+const Footer = styled.div`
+  margin-top: 40px; /* Added margin for spacing before the footer */
+  color: white;
+  text-align: center;
 `;
 
 const Licensing = () => {
@@ -67,7 +72,9 @@ const Licensing = () => {
                 SOFTWARE.
             </Paragraph>
             <Subtitle>Contact Information</Subtitle>
-            <p style={{ color: 'white' }}>If you have any questions or concerns about this licensing agreement, please contact us at Email: <a href="mailto:careerzunction@gmail.com" style={{ color: 'white' }}>careerzunction@gmail.com</a></p>
+            <Footer>
+                If you have any questions or concerns about this licensing agreement, please contact us at Email: <a href="mailto:careerzunction@gmail.com" style={{ color: 'white' }}>careerzunction@gmail.com</a>
+            </Footer>
         </Container>
     );
 };

--- a/src/Component/Licensing.jsx
+++ b/src/Component/Licensing.jsx
@@ -44,7 +44,7 @@ const Licensing = () => {
             <Title>Licensing</Title>
             <Paragraph>Welcome to CareerZunction! This website is licensed under the MIT License. This page outlines the terms of the license and provides details on how you can use, modify, and distribute our software.</Paragraph>
             <Subtitle>MIT License</Subtitle>
-            <Paragraph>Copyright (c) 2024 StartConnect-Hub</Paragraph>
+            <Paragraph>Copyright (c) 2024 CareerZunction</Paragraph>
             <Paragraph>
                 Permission is hereby granted, free of charge, to any person obtaining a copy
                 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hey @PSS2134 

- issue closes #465 

I have added and created licensing page reflecting MIT license

![image](https://github.com/user-attachments/assets/d9c3ff2f-8882-4bd9-aadf-4a0b015e8467)

Licensing Page: 

![image](https://github.com/user-attachments/assets/cc3a887d-6064-42ce-9b11-c3db11fc41c3)


