### PR TITLE
fixed check now button in home page

### DIFF
--- a/src/Style/Home.css
+++ b/src/Style/Home.css
@@ -85,6 +85,7 @@
   background-color: transparent;
   color: white;
   outline: thick double blueviolet;
+  width: max-content;
 }
 .home1 {
   margin-top: 100px;


### PR DESCRIPTION
As discussed under issue #452 , the check now button was overflowing earlier like this
![Screenshot 2024-07-21 183523](https://github.com/user-attachments/assets/6ece3b38-8c76-4e05-ae4c-8836119373cc)


I made it properly responsive for all device sizes so that it fits perfectly and no overflow happens

https://github.com/user-attachments/assets/f8f2bc89-420f-40b5-ae72-04677b100e6f

