### PR TITLE
Fix the preloader loading error

### DIFF
--- a/src/Component/Preloader.css
+++ b/src/Component/Preloader.css
@@ -4,7 +4,6 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background: #000000; 
     display: flex;
     justify-content: center;
     align-items: center;
@@ -19,6 +18,7 @@
     left: 50%;
     width: 100vw; 
     height: 100vh; 
+    z-index: 99999; 
     object-fit: cover; 
     transform: translate(-50%, -50%);
     filter: hue-rotate(200deg) saturate(2) brightness(1) contrast(1.2); 

--- a/src/Component/Preloader.css
+++ b/src/Component/Preloader.css
@@ -4,6 +4,7 @@
     left: 0;
     width: 100%;
     height: 100%;
+    background: #000000; 
     display: flex;
     justify-content: center;
     align-items: center;
@@ -17,8 +18,8 @@
     top: 50%;
     left: 50%;
     width: 100vw; 
-    height: 100vh; 
-    z-index: 99999; 
+    height: 100vh;
+    z-index: 9999;  
     object-fit: cover; 
     transform: translate(-50%, -50%);
     filter: hue-rotate(200deg) saturate(2) brightness(1) contrast(1.2); 

--- a/src/Component/Preloader.jsx
+++ b/src/Component/Preloader.jsx
@@ -18,7 +18,7 @@ const Preloader = () => {
     isVisible && (
       <div className={`preloader ${fadeOut ? 'fade-out' : ''}`}>
         <video autoPlay muted loop className="preloader-video">
-          <source src="/preloader.mp4" type="video/mp4" />
+          <source src="/Preloader.mp4" type="video/mp4" />
           Your browser does not support the video tag.
         </video>
       </div>


### PR DESCRIPTION
Hey @PSS2134 

I have made some changes in the files, I think the issue was with the naming convention 
I tried testing by redirecting to the assets from the deployed URL and found that `preloader.mp4` is not loaded as the file name and path were not consistent in the code. i.e. `Preloader.mp4`

![image](https://github.com/user-attachments/assets/0bda5a97-29f1-444b-9ead-4b9a026a68d8)


Let's see, This should work now!